### PR TITLE
fix: initialize metric labels using .labels()

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -44,22 +44,24 @@ class MetricExporter:
         Defines the Prometheus metrics object.
         Returns a dictionary of metrics.
         """
-        self.metrics["config_sample_metric"] = Gauge(
-            "sample_metric",
-            "This is a sample metric for the Datadog exporter.",
-            labels=tuple(self.default_labels.keys()),
-        )
+        if "config_sample_metric" not in self.metrics:
+            self.metrics["config_sample_metric"] = Gauge(
+                "sample_metric",
+                "This is a sample metric for the Datadog exporter.",
+            )
         return self.metrics
 
-    def add_metrics(self, metrics, value=None):
+    def add_metrics(self, metrics={}, value=None):
         """
         Adds the retrieved metrics to the pre-defined object.
         metrics: dict
             A dictionary of Prometheus metric objects.
         """
-        metrics["config_sample_metric"].add_metric(
-            labels=tuple(self.default_labels.values()), value=None
-        )
+        for metric_name, metric_object in metrics.items():
+            if metric_name not in self.metrics:
+                self.metrics[metric_name] = metric_object
+            else:
+                logging.warning(f"Metric '{metric_name}' already added.")
 
     def run_metrics_loop(self):
         while True:
@@ -246,7 +248,7 @@ class MetricExporter:
 
     def fetch(self):
         """
-        Fetch the metrics from the Datadog API and yield them.
+        Fetch the metrics from the Datadog API.
         """
         logger.info("Collecting the metrics for a Prometheus client")
 
@@ -257,6 +259,6 @@ class MetricExporter:
         self.get_monthly_cost_attribution(api_instance)
 
         metric_definitions = self.define_metrics()
-        self.add_metrics(metric_definitions, response)
+        self.add_metrics(metric_definitions, {})
 
-        yield from metric_definitions.values()
+        # yield from metric_definitions.values()


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

- Metrics with labels are not initialized when declared, because the client can’t know what values the label can have. It is recommended to initialize the label values by calling the .labels() method alone
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
