### PR TITLE
refactor: add generic create-api-client method

### DIFF
--- a/tests/test_datadog_cost_exporter.py
+++ b/tests/test_datadog_cost_exporter.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 from datetime import datetime
 from dateutil.parser import parse
 
@@ -8,41 +8,49 @@ from src.exporter import MetricExporter
 
 class TestMetricExporter(unittest.TestCase):
     def setUp(self):
-        self.exporter = MetricExporter(
-            polling_interval_seconds=60,
-            dd_api_key="your_api_key",
-            dd_app_key="your_app_key",
-            dd_host="your_dd_host",
-            dd_debug=False,
+        self.dd_api_key = "your_dd_api_key"
+        self.dd_app_key = "your_dd_app_key"
+        self.dd_host = "your_dd_host"
+        self.dd_debug = True
+        self.polling_interval_seconds = 60
+        self.metric_exporter = MetricExporter(
+            self.polling_interval_seconds, self.dd_api_key, self.dd_app_key, self.dd_host, self.dd_debug
         )
+
+    def test_create_api_client(self):
+        api_client = self.metric_exporter.create_api_client()
+        self.assertIsNotNone(api_client)
+
+    # @patch('src.exporter.UsageMeteringApi')
+    # def test_get_usage_metric_api_instance(self, mock_api):
+    #     api_instance = self.metric_exporter.get_usage_metric_api_instance()
+    #     mock_api.assert_called_once_with(api_instance.api_client)
+
+    # @patch('src.exporter.SpansMetricsApi')
+    # def test_get_spans_metrics_api_instance(self, mock_api):
+    #     api_instance = self.metric_exporter.get_spans_metrics_api_instance()
+    #     mock_api.assert_called_once_with(api_instance.api_client)
+
+    def test_define_metrics(self):
+        metrics = self.metric_exporter.define_metrics()
+        self.assertIsInstance(metrics, dict)
+        self.assertIn("config_sample_metric", metrics)
+        self.assertTrue(metrics["config_sample_metric"]._name == "sample_metric")
+
+    def test_add_metrics(self):
+        mock_metric = MagicMock()
+        metrics = {"mock_metric": mock_metric}
+        self.metric_exporter.add_metrics(metrics)
+        self.assertIn("mock_metric", self.metric_exporter.metrics)
+        self.assertEqual(self.metric_exporter.metrics["mock_metric"], mock_metric)
 
     @patch("src.exporter.time.sleep", side_effect=InterruptedError)
     @patch("src.exporter.MetricExporter.fetch")
     def test_run_metrics_loop(self, mock_fetch, mock_sleep):
         with self.assertRaises(InterruptedError):
-            self.exporter.run_metrics_loop()
+            self.metric_exporter.run_metrics_loop()
 
         mock_fetch.assert_called_once()
-
-    @patch("src.exporter.ApiClient")
-    @patch("src.exporter.UsageMeteringApi")
-    def test_get_api_instance(self, mock_usage_metering_api, mock_api_client):
-        api_instance = self.exporter.get_api_instance()
-
-        mock_api_client.assert_called_once()
-        mock_api_client.return_value.__enter__.assert_called_once()
-        mock_usage_metering_api.assert_called_once_with(
-            mock_api_client.return_value.__enter__.return_value
-        )
-
-        self.assertEqual(
-            mock_api_client.call_args[1]["configuration"].api_key["appKeyAuth"],
-            "your_app_key",
-        )
-        self.assertEqual(
-            mock_api_client.call_args[1]["configuration"].api_key["apiKeyAuth"],
-            "your_api_key",
-        )
 
     @patch("src.exporter.UsageMeteringApi")
     def test_get_projected_total_cost(self, mock_usage_metering_api):
@@ -68,7 +76,7 @@ class TestMetricExporter(unittest.TestCase):
         ]
         mock_api_instance.get_projected_monthly_cost.return_value = mock_response
 
-        self.exporter.get_projected_total_cost(mock_api_instance)
+        self.metric_exporter.get_projected_total_cost(mock_api_instance)
 
     # Add more test cases as needed
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

- Ensures we have a generic create api client method
- Allows use to get metric data from other endpoints which could be use for cost calculations

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
