### PR TITLE
feat: add methods to query estimated usage with a service breakdown

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install coverage coveralls
+          pip install coverage coveralls freezegun
           pip install -r requirements.txt
       - name: Run tests
         run: |

--- a/tests/test_datadog_cost_exporter.py
+++ b/tests/test_datadog_cost_exporter.py
@@ -85,27 +85,30 @@ class TestMetricExporter(unittest.TestCase):
 
         self.metric_exporter.get_projected_total_cost(mock_api_instance)
 
-    @patch('src.exporter.UsageMeteringApi')
-    @patch('src.exporter.Gauge')
+    @patch("src.exporter.UsageMeteringApi")
+    @patch("src.exporter.Gauge")
     @freeze_time("2024-01-01")
     def test_fetch(self, mock_gauge, mock_usage_metering_api):
         api_instance = mock_usage_metering_api.return_value
         self_instance = MetricExporter(
             polling_interval_seconds=60,
-            dd_api_key='fake_api_key',
-            dd_app_key='fake_app_key',
-            dd_host='fake_host',
-            dd_debug=True
+            dd_api_key="fake_api_key",
+            dd_app_key="fake_app_key",
+            dd_host="fake_host",
+            dd_debug=True,
         )
 
         api_instance.get_projected_cost.return_value = MagicMock()
-        api_instance.get_historical_cost_by_org.return_value = {'data': []}
-        api_instance.get_monthly_cost_attribution.return_value = {'data': [], 'meta': {'aggregates': []}}
+        api_instance.get_historical_cost_by_org.return_value = {"data": []}
+        api_instance.get_monthly_cost_attribution.return_value = {
+            "data": [],
+            "meta": {"aggregates": []},
+        }
 
         self_instance.fetch()
 
         api_instance.get_historical_cost_by_org.assert_called_once_with(
-            view='summary',
+            view="summary",
             start_month=(datetime.now() + relativedelta(months=-2)),
         )
         api_instance.get_monthly_cost_attribution.assert_called_once_with(
@@ -114,6 +117,7 @@ class TestMetricExporter(unittest.TestCase):
             fields="*",
         )
         mock_gauge.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR allows us the ability to query
- apm ingested bytes
- apm ingested spans
- logs ingested events
- logs ingested bytes
- infra host count

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
